### PR TITLE
Fix compilation warnings

### DIFF
--- a/src/InfluxDB.cpp
+++ b/src/InfluxDB.cpp
@@ -6,7 +6,7 @@
  #include "HttpClient.h"
  #include "InfluxDB.h"
 
- InfluxDB::InfluxDB(char* username, char* password)
+ InfluxDB::InfluxDB(const char* username, const char* password)
  {
    _username = username;
    _password = password;
@@ -21,12 +21,12 @@
    pvalue = (Value *)malloc(MAX_VALUES * sizeof(Value));
  }
 
- void InfluxDB::add(char *variable_id, double value)
+ void InfluxDB::add(const char *variable_id, double value)
  {
-   return add(variable_id, value, NULL);
+   return add(variable_id, value, 0UL);
  }
 
- void InfluxDB::add(char *variable_id, double value, unsigned long timestamp)
+ void InfluxDB::add(const char *variable_id, double value, unsigned long timestamp)
  {
    (pvalue + _currentValue)->idName = variable_id;
    (pvalue + _currentValue)->idValue = value;
@@ -48,7 +48,7 @@
 
  bool InfluxDB::sendAll()
  {
-   unsigned long lastTimestamp, currentTimestamp;
+   unsigned long currentTimestamp;
    String idMeasurement = _deviceName; // e.g. particle
    String tag_set = String::format("deviceID=%s", _deviceID.c_str()); // e.g. deviceID=54395594308
 

--- a/src/InfluxDB.h
+++ b/src/InfluxDB.h
@@ -19,7 +19,7 @@
 #define PORT 8086
 #endif
 #ifndef MAX_VALUES
-#define MAX_VALUES 1000
+#define MAX_VALUES 1000U
 #endif
 #ifndef DATABASE
 #define DATABASE "sensordata"
@@ -32,29 +32,29 @@
 #include "HttpClient.h"
 
 struct Value {
-    char  *idName;
-    float idValue;
+    const char    *idName;
+    float         idValue;
     unsigned long timestamp_val;
 };
 
 class InfluxDB
 {
 public:
-  InfluxDB(char* username, char* password);
-  void add(char *variable_id, double value);
-  void add(char *variable_id, double value, unsigned long timestamp);
+  InfluxDB(const char* username, const char* password);
+  void add(const char *variable_id, double value);
+  void add(const char *variable_id, double value, unsigned long timestamp);
   bool sendAll();
   String setDatabase(String databaseName);
   String setDeviceName(String databaseName);
   void setDebug(bool debug);
 private:
-  char* _username;
-  char* _password;
+  const char* _username;
+  const char* _password;
   String _deviceID;
   String _deviceName;
   String _databaseName;
   Value* pvalue;
-  uint8_t _currentValue;
+  uint16_t _currentValue;
   HttpClient http;
   http_request_t request;
   http_response_t response;


### PR DESCRIPTION
When using Particle Workbench in Visual Studio Code to compile the code, numerous warnings appear when calling into the library. 

Also, `_currentValue` is not wide enough to accommodate the value 1000:

> warning: conversion from 'unsigned int' to 'uint8_t' {aka 'unsigned char'} changes value from '1000' to '232' [-Woverflow]